### PR TITLE
Feat: scalar support

### DIFF
--- a/deps/api-requirements.in
+++ b/deps/api-requirements.in
@@ -7,3 +7,4 @@ pyhumps
 anthropic
 openai
 jinja2
+scalar-fastapi

--- a/src/mc_bench/apps/admin_api/app.py
+++ b/src/mc_bench/apps/admin_api/app.py
@@ -2,7 +2,6 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse
 from scalar_fastapi import get_scalar_api_reference
 
 from mc_bench.apps.admin_api.routers.generations import generation_router
@@ -32,6 +31,6 @@ app.include_router(run_router)
 @app.get("/scalar", include_in_schema=False)
 async def scalar_docs():
     return get_scalar_api_reference(
-        openapi_url="/openapi.json",  # This is FastAPI's default OpenAPI endpoint
+        openapi_url="/openapi.json",
         title="MC Bench Admin API",
     )

--- a/src/mc_bench/apps/admin_api/app.py
+++ b/src/mc_bench/apps/admin_api/app.py
@@ -2,6 +2,8 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
+from scalar_fastapi import get_scalar_api_reference
 
 from mc_bench.apps.admin_api.routers.generations import generation_router
 from mc_bench.apps.admin_api.routers.models import model_router
@@ -26,3 +28,10 @@ app.include_router(prompt_router)
 app.include_router(model_router)
 app.include_router(generation_router)
 app.include_router(run_router)
+
+@app.get("/scalar", include_in_schema=False)
+async def scalar_docs():
+    return get_scalar_api_reference(
+        openapi_url="/openapi.json",  # This is FastAPI's default OpenAPI endpoint
+        title="MC Bench Admin API",
+    )

--- a/src/mc_bench/apps/api/app.py
+++ b/src/mc_bench/apps/api/app.py
@@ -2,6 +2,7 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from scalar_fastapi import get_scalar_api_reference
 
 from mc_bench.apps.api.routers.comparison import comparison_router
 from mc_bench.apps.api.routers.user import user_router
@@ -23,3 +24,10 @@ app.add_middleware(
 
 app.include_router(user_router)
 app.include_router(comparison_router)
+
+@app.get("/scalar", include_in_schema=False)
+async def scalar_docs():
+    return get_scalar_api_reference(
+        openapi_url="/openapi.json",
+        title="MC Bench API",
+    )


### PR DESCRIPTION
Add Scalar UI as alternative OpenAPI documentation for admin and default APIs. 
Easier to parse, test, and understand.
<img width="1457" alt="Screenshot 2024-12-17 at 10 55 02 AM" src="https://github.com/user-attachments/assets/2ff99507-d9a9-4876-918c-a4779e249fd7" />
Compared to 
<img width="1459" alt="Screenshot 2024-12-17 at 10 55 19 AM" src="https://github.com/user-attachments/assets/8d3e3b47-0a5f-4596-99ff-a878ef64c60a" />
