### PR TITLE
Fix worker deployment configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,7 @@ services:
       HUMANIZE_LOGS: ${HUMANIZE_LOGS:-false}
       SHOW_VERBOSE_SQL: ${SHOW_VERBOSE_SQL:-false}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
-      CONTAINER_NAME: "worker-local"
-    command: celery -A mc_bench.apps.worker worker -Q default --concurrency ${NUM_WORKERS:-1} -n "worker-local@localhost"
+      WORKER_NAME: "worker-local@localhost"
 
   admin-worker:
     build:
@@ -111,7 +110,7 @@ services:
       SHOW_VERBOSE_SQL: ${SHOW_VERBOSE_SQL:-false}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_INTERVAL_COMMANDS: ${LOG_INTERVAL_COMMANDS:-50}
-      CONTAINER_NAME: "admin-worker-local"
+      WORKER_NAME: "admin-worker-local@localhost"
 
       # LLM Service API Keys
       ALIBABA_CLOUD_API_KEY: ${ALIBABA_CLOUD_API_KEY}
@@ -124,7 +123,6 @@ services:
       MISTRAL_API_KEY: ${MISTRAL_API_KEY}
       REKA_API_KEY: ${REKA_API_KEY}
       ZHIPUAI_API_KEY: ${ZHIPUAI_API_KEY}
-    command: celery -A mc_bench.apps.admin_worker worker -Q admin --concurrency ${NUM_WORKERS:-4} -n "admin-worker-local@localhost"
 
   render-worker:
     platform: linux/amd64
@@ -154,8 +152,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_INTERVAL_BLOCKS: ${LOG_INTERVAL_BLOCKS:-100}
       LOG_INTERVAL_MATERIALS: ${LOG_INTERVAL_MATERIALS:-10}
-      CONTAINER_NAME: "render-worker-local"
-    command: celery -A mc_bench.apps.render_worker worker -Q render --concurrency ${NUM_WORKERS:-1} -n "render-worker-local@localhost"
+      WORKER_NAME: "render-worker-local@localhost"
 
   server-worker:
     build:
@@ -191,11 +188,9 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_INTERVAL_COMMANDS: ${LOG_INTERVAL_COMMANDS:-50}
       LOG_INTERVAL_EXPORT_PERCENT: ${LOG_INTERVAL_EXPORT_PERCENT:-10}
-      CONTAINER_NAME: "server-worker-local"
-
+      WORKER_NAME: "server-worker-local@localhost"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: celery -A mc_bench.apps.server_worker worker -Q server --concurrency ${NUM_WORKERS:-1} -n "server-worker-local@localhost"
 
   admin-flower:
     build:

--- a/images/admin-worker.Dockerfile
+++ b/images/admin-worker.Dockerfile
@@ -11,4 +11,4 @@ RUN pip install /usr/lib/mc-bench-backend[admin-worker]
 
 ENV NUM_WORKERS=4
 ENTRYPOINT []
-CMD exec celery -A mc_bench.apps.admin_worker worker -Q admin --concurrency $NUM_WORKERS
+CMD exec celery -A mc_bench.apps.admin_worker worker -Q admin --concurrency $NUM_WORKERS -n $WORKER_NAME

--- a/images/render-worker.Dockerfile
+++ b/images/render-worker.Dockerfile
@@ -12,4 +12,4 @@ RUN pip install /usr/lib/mc-bench-backend[render-worker]
 ENV NUM_WORKERS=1
 
 ENTRYPOINT []
-CMD exec celery -A mc_bench.apps.render_worker worker -Q render --concurrency $NUM_WORKERS
+CMD exec celery -A mc_bench.apps.render_worker worker -Q render --concurrency $NUM_WORKERS -n $WORKER_NAME

--- a/images/server-worker.Dockerfile
+++ b/images/server-worker.Dockerfile
@@ -10,4 +10,4 @@ RUN pip install /usr/lib/mc-bench-backend[server-worker]
 ENV NUM_WORKERS=1
 
 ENTRYPOINT []
-CMD exec celery -A mc_bench.apps.server_worker worker -Q server --concurrency $NUM_WORKERS
+CMD exec celery -A mc_bench.apps.server_worker worker -Q server --concurrency $NUM_WORKERS -n $WORKER_NAME

--- a/images/worker.Dockerfile
+++ b/images/worker.Dockerfile
@@ -10,4 +10,4 @@ RUN pip install /usr/lib/mc-bench-backend[worker]
 ENV NUM_WORKERS=1
 
 ENTRYPOINT []
-CMD exec celery -A mc_bench.apps.worker worker -Q default --concurrency $NUM_WORKERS
+CMD exec celery -A mc_bench.apps.worker worker -Q default --concurrency $NUM_WORKERS -n $WORKER_NAME


### PR DESCRIPTION
Standardize worker naming configuration by moving command arguments to Dockerfiles and using WORKER_NAME environment variable. This allows for consistent worker naming across local development and production deployments.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>