### PR TITLE
Move worker command args to Dockerfiles

### DIFF
--- a/deploy/admin-worker-deploy.sh
+++ b/deploy/admin-worker-deploy.sh
@@ -39,9 +39,8 @@ docker run -d --name "$NEW_CONTAINER_NAME" \
     --pull always \
     --rm \
     --env-file /opt/secrets/.env \
-    -e CONTAINER_NAME="$NEW_CONTAINER_NAME" \
-    "$REGISTRY/$IMAGE_NAME:$TAG" \
-    celery -A mc_bench.apps.admin_worker worker -Q admin --concurrency $NUM_WORKERS -n "${NEW_CONTAINER_NAME}@${HOSTNAME}"
+    -e WORKER_NAME="${NEW_CONTAINER_NAME}@${HOSTNAME}" \
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 # Create run script for manual execution
 cat > /opt/run-${CONTAINER_PREFIX}.sh << EOF
@@ -60,9 +59,8 @@ HOSTNAME=\$(hostname)
 docker run -d --name "\$MANUAL_CONTAINER_NAME" \\
     --rm \\
     --env-file /opt/secrets/.env \\
-    -e CONTAINER_NAME="\$MANUAL_CONTAINER_NAME" \\
-    "$REGISTRY/$IMAGE_NAME:$TAG" \\
-    celery -A mc_bench.apps.admin_worker worker -Q admin --concurrency \$NUM_WORKERS -n "\${MANUAL_CONTAINER_NAME}@\${HOSTNAME}"
+    -e WORKER_NAME="\$MANUAL_CONTAINER_NAME@\$HOSTNAME" \\
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 echo "Started admin worker container: \$MANUAL_CONTAINER_NAME"
 echo "To view logs: docker logs -f \$MANUAL_CONTAINER_NAME"

--- a/deploy/render-worker-deploy.sh
+++ b/deploy/render-worker-deploy.sh
@@ -40,9 +40,8 @@ docker run -d --name "$NEW_CONTAINER_NAME" \
     --pull always \
     --rm \
     --env-file /opt/secrets/.env \
-    -e CONTAINER_NAME="$NEW_CONTAINER_NAME" \
-    "$REGISTRY/$IMAGE_NAME:$TAG" \
-    celery -A mc_bench.apps.render_worker worker -Q render --concurrency $NUM_WORKERS -n "${NEW_CONTAINER_NAME}@${HOSTNAME}"
+    -e WORKER_NAME="${NEW_CONTAINER_NAME}@${HOSTNAME}" \
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 # Create run script for manual execution
 cat > /opt/run-${CONTAINER_PREFIX}.sh << EOF
@@ -61,9 +60,8 @@ HOSTNAME=\$(hostname)
 docker run -d --name "\$MANUAL_CONTAINER_NAME" \\
     --rm \\
     --env-file /opt/secrets/.env \\
-    -e CONTAINER_NAME="\$MANUAL_CONTAINER_NAME" \\
-    "$REGISTRY/$IMAGE_NAME:$TAG" \\
-    celery -A mc_bench.apps.render_worker worker -Q render --concurrency \$NUM_WORKERS -n "\${MANUAL_CONTAINER_NAME}@\${HOSTNAME}"
+    -e WORKER_NAME="\$MANUAL_CONTAINER_NAME@\$HOSTNAME" \\
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 echo "Started render worker container: \$MANUAL_CONTAINER_NAME"
 echo "To view logs: docker logs -f \$MANUAL_CONTAINER_NAME"

--- a/deploy/server-worker-deploy.sh
+++ b/deploy/server-worker-deploy.sh
@@ -43,11 +43,10 @@ docker run -d --name "$NEW_CONTAINER_NAME" \
     --pull always \
     --rm \
     --env-file /opt/secrets/.env \
-    -e CONTAINER_NAME="$NEW_CONTAINER_NAME" \
+    -e WORKER_NAME="${NEW_CONTAINER_NAME}@${HOSTNAME}" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /root/.docker/config.json:/root/.docker/config.json \
-    "$REGISTRY/$IMAGE_NAME:$TAG" \
-    celery -A mc_bench.apps.server_worker worker -Q server --concurrency $NUM_WORKERS -n "${NEW_CONTAINER_NAME}@${HOSTNAME}"
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 # Create run script for manual execution
 cat > /opt/run-${CONTAINER_PREFIX}.sh << EOF
@@ -66,11 +65,10 @@ HOSTNAME=\$(hostname)
 docker run -d --name "\$MANUAL_CONTAINER_NAME" \\
     --rm \\
     --env-file /opt/secrets/.env \\
-    -e CONTAINER_NAME="\$MANUAL_CONTAINER_NAME" \\
+    -e WORKER_NAME="\$MANUAL_CONTAINER_NAME@\$HOSTNAME" \\
     -v /var/run/docker.sock:/var/run/docker.sock \\
     -v /root/.docker/config.json:/root/.docker/config.json \\
-    "$REGISTRY/$IMAGE_NAME:$TAG" \\
-    celery -A mc_bench.apps.server_worker worker -Q server --concurrency \$NUM_WORKERS -n "\${MANUAL_CONTAINER_NAME}@\${HOSTNAME}"
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 echo "Started server worker container: \$MANUAL_CONTAINER_NAME"
 echo "To view logs: docker logs -f \$MANUAL_CONTAINER_NAME"

--- a/deploy/worker-deploy.sh
+++ b/deploy/worker-deploy.sh
@@ -39,9 +39,8 @@ docker run -d --name "$NEW_CONTAINER_NAME" \
     --pull always \
     --rm \
     --env-file /opt/secrets/.env \
-    -e CONTAINER_NAME="$NEW_CONTAINER_NAME" \
-    "$REGISTRY/$IMAGE_NAME:$TAG" \
-    celery -A mc_bench.apps.worker worker -Q default --concurrency $NUM_WORKERS -n "${NEW_CONTAINER_NAME}@${HOSTNAME}"
+    -e WORKER_NAME="${NEW_CONTAINER_NAME}@${HOSTNAME}" \
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 # Create run script for manual execution
 cat > /opt/run-${CONTAINER_PREFIX}.sh << EOF
@@ -60,9 +59,8 @@ HOSTNAME=\$(hostname)
 docker run -d --name "\$MANUAL_CONTAINER_NAME" \\
     --rm \\
     --env-file /opt/secrets/.env \\
-    -e CONTAINER_NAME="\$MANUAL_CONTAINER_NAME" \\
-    "$REGISTRY/$IMAGE_NAME:$TAG" \\
-    celery -A mc_bench.apps.worker worker -Q default --concurrency \$NUM_WORKERS -n "\${MANUAL_CONTAINER_NAME}@\${HOSTNAME}"
+    -e WORKER_NAME="\$MANUAL_CONTAINER_NAME@\$HOSTNAME" \\
+    "$REGISTRY/$IMAGE_NAME:$TAG"
 
 echo "Started worker container: \$MANUAL_CONTAINER_NAME"
 echo "To view logs: docker logs -f \$MANUAL_CONTAINER_NAME"


### PR DESCRIPTION
Replace command-line Celery arguments with environment variables for worker configuration, allowing consistent entrypoint usage across deployment scripts.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>