### PR TITLE
Fix task queue routing for worker processes

### DIFF
--- a/images/admin-worker.Dockerfile
+++ b/images/admin-worker.Dockerfile
@@ -11,4 +11,4 @@ RUN pip install /usr/lib/mc-bench-backend[admin-worker]
 
 ENV NUM_WORKERS=4
 ENTRYPOINT []
-CMD exec celery -A mc_bench.apps.admin_worker worker -Q admin --concurrency $NUM_WORKERS -n $WORKER_NAME
+CMD exec celery -A mc_bench.apps.admin_worker worker -Q admin,generation,prompt,parse,validate,post_process,prepare --concurrency $NUM_WORKERS -n $WORKER_NAME

--- a/src/mc_bench/apps/admin_api/celery.py
+++ b/src/mc_bench/apps/admin_api/celery.py
@@ -13,6 +13,7 @@ def create_runs(
 ):
     return send_task(
         "generation.create_runs",
+        queue="generation",
         kwargs=dict(
             generation_id=generation_id,
             prompt_ids=prompt_ids,

--- a/src/mc_bench/apps/admin_api/routers/infra.py
+++ b/src/mc_bench/apps/admin_api/routers/infra.py
@@ -44,6 +44,12 @@ BASE_QUEUE_NAMES = [
     "render",
     "server",
     "admin",
+    "generation",
+    "prompt",
+    "parse",
+    "validate",
+    "post_process",
+    "prepare",
 ]
 
 

--- a/src/mc_bench/apps/admin_worker/tasks/generation.py
+++ b/src/mc_bench/apps/admin_worker/tasks/generation.py
@@ -77,19 +77,21 @@ def create_runs(
                             "sample_id": None,
                         }
                     ],
-                    queue="admin",
+                    queue="prompt",
                     headers=headers,
                 ),
-                app.signature("run.parse_prompt", queue="admin", headers=headers),
-                app.signature("run.code_validation", queue="admin", headers=headers),
+                app.signature("run.parse_prompt", queue="parse", headers=headers),
+                app.signature("run.code_validation", queue="validate", headers=headers),
                 app.signature("run.build_structure", queue="server", headers=headers),
                 app.signature("run.render_sample", queue="render", headers=headers),
                 # TODO: Add exporting content back in once implemented in blender
                 # app.signature(
                 #     "run.export_structure_views", queue="server", headers=headers
                 # ),
-                app.signature("run.post_processing", queue="admin", headers=headers),
-                app.signature("run.prepare_sample", queue="admin", headers=headers),
+                app.signature(
+                    "run.post_processing", queue="post_process", headers=headers
+                ),
+                app.signature("run.prepare_sample", queue="prepare", headers=headers),
             )
             for run_id in run_ids
         )

--- a/src/mc_bench/migrations/versions/e69015b27346_fix_admin_api_permissions.py
+++ b/src/mc_bench/migrations/versions/e69015b27346_fix_admin_api_permissions.py
@@ -47,7 +47,6 @@ def upgrade() -> None:
         """)
     )
 
-
     # Grant DELETE permissions to admin-api role for template management
     op.execute(
         sa.text("""\

--- a/src/mc_bench/models/run.py
+++ b/src/mc_bench/models/run.py
@@ -818,7 +818,7 @@ class PromptExecution(RunStage):
 
     def get_task_signature(self, app, progress_token, pass_args=True):
         kwargs = {}
-        kwargs["queue"] = "admin"
+        kwargs["queue"] = "prompt"
         kwargs["headers"] = {"token": progress_token}
         if pass_args:
             kwargs["args"] = [
@@ -836,7 +836,7 @@ class ResponseParsing(RunStage):
 
     def get_task_signature(self, app, progress_token, pass_args=True):
         kwargs = {}
-        kwargs["queue"] = "admin"
+        kwargs["queue"] = "parse"
         kwargs["headers"] = {"token": progress_token}
         if pass_args:
             sample_id = self.run.samples[-1].id
@@ -855,7 +855,7 @@ class CodeValidation(RunStage):
 
     def get_task_signature(self, app, progress_token, pass_args=True):
         kwargs = {}
-        kwargs["queue"] = "admin"
+        kwargs["queue"] = "validate"
         kwargs["headers"] = {"token": progress_token}
         if pass_args:
             sample_id = self.run.samples[-1].id
@@ -912,7 +912,7 @@ class PostProcessing(RunStage):
 
     def get_task_signature(self, app, progress_token, pass_args=True):
         kwargs = {}
-        kwargs["queue"] = "admin"
+        kwargs["queue"] = "post_process"
         kwargs["headers"] = {"token": progress_token}
         if pass_args:
             sample_id = self.run.samples[-1].id
@@ -931,7 +931,7 @@ class PreparingSample(RunStage):
 
     def get_task_signature(self, app, progress_token, pass_args=True):
         kwargs = {}
-        kwargs["queue"] = "admin"
+        kwargs["queue"] = "prepare"
         kwargs["headers"] = {"token": progress_token}
         if pass_args:
             sample_id = self.run.samples[-1].id

--- a/src/mc_bench/worker/run_stage.py
+++ b/src/mc_bench/worker/run_stage.py
@@ -234,7 +234,7 @@ def run_stage_task(
                         app.signature(
                             "generation.finalize_generation",
                             args=[generation_id],
-                            queue="admin",
+                            queue="generation",
                         ).apply_async()
 
         return wrapped


### PR DESCRIPTION
- Split admin worker tasks into specialized queues (generation, prompt, parse, validate, post_process, prepare)
- Update Dockerfile to listen on all specialized queues
- Update task signatures to route to appropriate queues
- Improve celery task routing for better load distribution

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>