### PR TITLE
fix: Prevent table locking from uncommitted transactions in tasks

### DIFF
--- a/src/mc_bench/worker/run_stage.py
+++ b/src/mc_bench/worker/run_stage.py
@@ -161,6 +161,10 @@ def run_stage_task(
                     logger.debug(f"Started heartbeat thread for task {task_id}")
 
                     result = func(stage_context)
+                    # Commit here to ensure any transactions started by the stage are committed
+                    # Otherwise we may run into DB locking issues
+                    db.commit()
+
                     logger.info("Task completed successfully", result=result)
                     emit_event(
                         RunStageStateChanged(


### PR DESCRIPTION
Was running into DB locking issues when running locally. The specific cause in my case appears to have been the code validation task. I'm not entirely positive, but it seems the `code = stage_context.sample.result_code_text` lookup in the code validation flow starts a DB transaction which ends up locking the RunStage(Sample → Run → RunStage dependencies possibly?)

This change adds a db.commit() after running stage tasks to ensure any dangling transactions are committed.
