### PR TITLE
✨ Feat: uv and minio bucket setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ build-deps-images:
 	docker build --platform linux/amd64 --build-arg PYTHON_VERSION=3.11.7 -t mcbench/deps-builder:3.11.7 -f images/deps-builder.Dockerfile .
 
 install-dev:
-	pip install -e ".[dev]"
+	pip install uv
+	uv pip install -e ".[dev]"
 
 fmt:
 	ruff check --select I,T20 --fix
@@ -42,14 +43,11 @@ reset:
 	docker-compose down -v
 	source .env || echo "Be sure to create .env in the root per the template"
 	# TODO: Check for local minecraft server and minecraft builder images
-	docker-compose up -d postgres redis object
+	docker-compose up -d postgres redis object object-init
 	echo "Sleeping for 10 seconds to let the database come up"
 	sleep 10
 	make install-dev
 	mc-bench-alembic upgrade head
-	docker-compose exec object sh -c "mc alias set object http://localhost:9000 fake_key fake_secret && \
-		mc mb object/mcbench-backend-object-local && mc anonymous set download object/mcbench-backend-object-local && \
-		mc mb object/mcbench-object-cdn-local && mc anonymous set download object/mcbench-object-cdn-local"
 
 	docker-compose up -d --build
 

--- a/dev/seed-data.sql
+++ b/dev/seed-data.sql
@@ -147,19 +147,16 @@ Remember:
 - The build is intended for human consumption in game and for visual display. When producing the build, consider how it can be viewed, explored, and used.
 ') ON CONFLICT DO NOTHING;
 
-INSERT INTO specification.model (created_by, slug, name, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'claude-3-5-sonnet-20241022', 'Claude 3.5 Sonnet (2024-10-22)', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, name, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'gpt-4o-2024-11-20', 'GPT-4o (2024-11-20)', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, name, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'llama-3.1-405b-instruct', 'Llama 3.1 405B Instruct', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, name, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'gemini-2.0-flash-exp', 'Gemini 2.0 Flash Exp', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, name, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'grok-2-1212', 'Grok 2.1 (1212)', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, name, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'deepseek-r1', 'DeepSeek R1', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'claude-3-5-sonnet-20241022', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'claude-3-7-sonnet-20250219', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'gpt-4o-2024-11-20', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'llama-3.1-405b-instruct', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'gemini-2.0-flash-exp', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'grok-2-1212', true) ON CONFLICT DO NOTHING;
-INSERT INTO specification.model (created_by, slug, active) VALUES ((select id from auth.user where username = 'SYSTEM'), 'deepseek-r1', true) ON CONFLICT DO NOTHING;
+INSERT INTO specification.model (created_by, slug, name, active) 
+VALUES 
+    ((select id from auth.user where username = 'SYSTEM'), 'claude-3-5-sonnet-20241022', 'Claude 3.5 Sonnet (2024-10-22)', true),
+    ((select id from auth.user where username = 'SYSTEM'), 'claude-3-7-sonnet-20250219', 'Claude 3.7 Sonnet (2025-02-19)', true),
+    ((select id from auth.user where username = 'SYSTEM'), 'gpt-4o-2024-11-20', 'GPT-4o (2024-11-20)', true),
+    ((select id from auth.user where username = 'SYSTEM'), 'llama-3.1-405b-instruct', 'Llama 3.1 405B Instruct', true),
+    ((select id from auth.user where username = 'SYSTEM'), 'gemini-2.0-flash-exp', 'Gemini 2.0 Flash Exp', true),
+    ((select id from auth.user where username = 'SYSTEM'), 'grok-2-1212', 'Grok 2.1 (1212)', true),
+    ((select id from auth.user where username = 'SYSTEM'), 'deepseek-r1', 'DeepSeek R1', true)
+ON CONFLICT (slug) DO NOTHING;
 
 INSERT INTO specification.provider (id, created_by, model_id, provider_class, config, name, is_default) VALUES (1, (select id from auth.user where username = 'SYSTEM'), (select id from specification.model where slug = 'claude-3-5-sonnet-20241022'), 'ANTHROPIC_SDK', '"{\"model\": \"claude-3-5-sonnet-20241022\", \"max_tokens\": 4000}"', 'claude-3-5-sonnet-20241022', true) ON CONFLICT DO NOTHING;
 INSERT INTO specification.provider (id, created_by, model_id, provider_class, config, name, is_default) VALUES (7, (select id from auth.user where username = 'SYSTEM'), (select id from specification.model where slug = 'claude-3-7-sonnet-20250219'), 'ANTHROPIC_SDK', '"{\"model\": \"claude-3-7-sonnet-20250219\", \"max_tokens\": 4000}"', 'claude-3-7-sonnet-20250219', true) ON CONFLICT DO NOTHING;
@@ -248,7 +245,8 @@ ON CONFLICT DO NOTHING;
 INSERT INTO auth.user (username)
 VALUES
     ('huntcsg'),
-    ('Isaac');
+    ('Isaac')
+ON CONFLICT (username) DO NOTHING;
 
 WITH auth_provider as (
     select
@@ -270,7 +268,8 @@ VALUES
      147355120,
      (select id from auth.user where username = 'Isaac'),
      'f89ba90d514fbeefd5d2115b3f49fd7520480d9f94937a1e4794598aa124450a'
-    );
+    )
+ON CONFLICT (auth_provider_id, auth_provider_user_id) DO NOTHING;
 
 INSERT INTO auth.user_role (created_by, user_id, role_id)
 SELECT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,21 @@ services:
       MINIO_ROOT_USER: fake_key
       MINIO_ROOT_PASSWORD: fake_secret
     command: ["server", "/data", "--console-address", "0.0.0.0:9001"]
+  
+  object-init:
+    image: minio/mc
+    depends_on:
+      - object
+    restart: "no"
+    entrypoint: >
+      /bin/sh -c "
+      /bin/sleep 5 &&
+      /usr/bin/mc alias set object http://object:9000 fake_key fake_secret &&
+      /usr/bin/mc mb object/mcbench-backend-object-local --ignore-existing &&
+      /usr/bin/mc anonymous set download object/mcbench-backend-object-local &&
+      /usr/bin/mc mb object/mcbench-object-cdn-local --ignore-existing &&
+      /usr/bin/mc anonymous set download object/mcbench-object-cdn-local
+      "
 
 volumes:
   minio-data:

--- a/images/admin-api.Dockerfile
+++ b/images/admin-api.Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.12.7
 
+RUN pip install uv
+
 COPY deps/requirements.txt requirements.txt
 COPY deps/api-requirements.txt api-requirements.txt
-RUN pip install -r requirements.txt -r api-requirements.txt
+RUN uv pip install --system -r requirements.txt -r api-requirements.txt
 
 COPY . /usr/lib/mc-bench-backend
-RUN pip install /usr/lib/mc-bench-backend[api]
+RUN uv pip install --system /usr/lib/mc-bench-backend[api]
 
 CMD ["uvicorn", "mc_bench.apps.admin_api.__main__:app", "--proxy-headers", "--port", "8000", "--host", "0.0.0.0"]

--- a/images/admin-worker.Dockerfile
+++ b/images/admin-worker.Dockerfile
@@ -2,12 +2,14 @@ FROM mcbenchmark/minecraft-builder-base:2024-12-11
 
 RUN npm install -g eslint
 
+RUN pip install uv
+
 COPY deps/requirements.txt requirements.txt
 COPY deps/admin-worker-requirements.txt admin-worker-requirements.txt
-RUN pip install -r requirements.txt -r admin-worker-requirements.txt
+RUN uv pip install --system -r requirements.txt -r admin-worker-requirements.txt
 
 COPY . /usr/lib/mc-bench-backend
-RUN pip install /usr/lib/mc-bench-backend[admin-worker]
+RUN uv pip install --system /usr/lib/mc-bench-backend[admin-worker]
 
 ENV NUM_WORKERS=4
 ENTRYPOINT []

--- a/images/api.Dockerfile
+++ b/images/api.Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.12.7
 
+RUN pip install uv
+
 COPY deps/requirements.txt requirements.txt
 COPY deps/api-requirements.txt api-requirements.txt
-RUN pip install -r requirements.txt -r api-requirements.txt
+RUN uv pip install --system -r requirements.txt -r api-requirements.txt
 
 COPY . /usr/lib/mc-bench-backend
-RUN pip install /usr/lib/mc-bench-backend[api]
+RUN uv pip install --system /usr/lib/mc-bench-backend[api]
 
 CMD ["uvicorn", "mc_bench.apps.api.__main__:app", "--proxy-headers", "--port", "8000", "--host", "0.0.0.0"]

--- a/images/deps-builder.Dockerfile
+++ b/images/deps-builder.Dockerfile
@@ -1,4 +1,4 @@
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION}-slim
 
-RUN pip install pip-tools
+RUN pip install uv

--- a/images/render-worker.Dockerfile
+++ b/images/render-worker.Dockerfile
@@ -2,12 +2,14 @@ FROM python:3.11.7
 
 RUN apt-get update && apt-get install -y blender
 
+RUN pip install uv
+
 COPY deps/requirements.txt requirements.txt
 COPY deps/render-worker-requirements.txt render-worker-requirements.txt
-RUN pip install -r requirements.txt -r render-worker-requirements.txt
+RUN uv pip install --system -r requirements.txt -r render-worker-requirements.txt
 
 COPY . /usr/lib/mc-bench-backend
-RUN pip install /usr/lib/mc-bench-backend[render-worker]
+RUN uv pip install --system /usr/lib/mc-bench-backend[render-worker]
 
 ENV NUM_WORKERS=1
 

--- a/images/server-worker.Dockerfile
+++ b/images/server-worker.Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.12.7
 
+RUN pip install uv
+
 COPY deps/requirements.txt requirements.txt
 COPY deps/server-worker-requirements.txt server-worker-requirements.txt
-RUN pip install -r requirements.txt -r server-worker-requirements.txt
+RUN uv pip install --system -r requirements.txt -r server-worker-requirements.txt
 
 COPY . /usr/lib/mc-bench-backend
-RUN pip install /usr/lib/mc-bench-backend[server-worker]
+RUN uv pip install --system /usr/lib/mc-bench-backend[server-worker]
 
 ENV NUM_WORKERS=1
 

--- a/images/worker.Dockerfile
+++ b/images/worker.Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.12.7
 
+RUN pip install uv
+
 COPY deps/requirements.txt requirements.txt
 COPY deps/worker-requirements.txt worker-requirements.txt
-RUN pip install -r requirements.txt -r worker-requirements.txt
+RUN uv pip install --system -r requirements.txt -r worker-requirements.txt
 
 COPY . /usr/lib/mc-bench-backend
-RUN pip install /usr/lib/mc-bench-backend[worker]
+RUN uv pip install --system /usr/lib/mc-bench-backend[worker]
 
 ENV NUM_WORKERS=1
 


### PR DESCRIPTION
Low hanging fruit PR - just some simple quality of life tweaks for local setup and build times.
UV to make docker compile times a bit quicker (we're not using UV for the env, just literally to replace pip).
Give it a shot, it's a nice upgrade and it doesn't impact anything else.
Adding the minio creation in the docker yml because a person shouldn't have to know to run this very specific command from ```make reset``` to get the entire setup running.
```
	docker-compose exec object sh -c "mc alias set object http://localhost:9000 fake_key fake_secret && \
		mc mb object/mcbench-backend-object-local && mc anonymous set download object/mcbench-backend-object-local && \
		mc mb object/mcbench-object-cdn-local && mc anonymous set download object/mcbench-object-cdn-local"
```

And of course tweaking the seed script.

I think this is all fine except maybe the deps-builders dockerfile.

This is my initial attempt.