### PR TITLE
Add bulk sample approval endpoint and generation statistics

### DIFF
--- a/src/mc_bench/apps/admin_api/transport_types/requests.py
+++ b/src/mc_bench/apps/admin_api/transport_types/requests.py
@@ -116,6 +116,12 @@ class SampleApprovalRequest(SampleActionRequest):
     test_set_id: uuid.UUID
 
 
+class BulkSampleApprovalRequest(Base):
+    """Request model for bulk approving samples from a generation."""
+    test_set_id: uuid.UUID
+    note: Optional[str] = None
+
+
 class AddPromptTagRequest(Base):
     tag_name: str
 

--- a/src/mc_bench/apps/admin_api/transport_types/responses.py
+++ b/src/mc_bench/apps/admin_api/transport_types/responses.py
@@ -175,6 +175,10 @@ class GenerationResponse(GenerationBaseResponse):
     pending_runs: int
     completed_runs: int
     failed_runs: int
+    total_samples: int
+    approved_samples: int
+    rejected_samples: int
+    pending_approval_samples: int
 
 
 class GenerationDetailResponse(GenerationResponse):
@@ -410,3 +414,10 @@ class CancelConsumerResponse(Base):
 
     success: bool
     message: str
+
+
+class BulkSampleApprovalResponse(Base):
+    """Response for bulk sample approval operation."""
+
+    total_approved: int
+    remaining_pending: int

--- a/src/mc_bench/models/run.py
+++ b/src/mc_bench/models/run.py
@@ -727,6 +727,28 @@ class Generation(Base):
             result["pending_runs"] = 0
             result["completed_runs"] = 0
             result["failed_runs"] = 0
+            
+            # Sample approval statistics
+            total_samples = 0
+            approved_samples = 0
+            rejected_samples = 0
+            pending_approval_samples = 0
+            
+            for run in self.runs:
+                for sample in run.samples:
+                    total_samples += 1
+                    if sample.approval_state:
+                        if sample.approval_state.name == "APPROVED":
+                            approved_samples += 1
+                        elif sample.approval_state.name == "REJECTED":
+                            rejected_samples += 1
+                    elif sample.is_complete and sample.experimental_state and sample.experimental_state.name == "RELEASED":
+                        pending_approval_samples += 1
+            
+            result["total_samples"] = total_samples
+            result["approved_samples"] = approved_samples
+            result["rejected_samples"] = rejected_samples
+            result["pending_approval_samples"] = pending_approval_samples
 
         return result
 


### PR DESCRIPTION
- Add endpoint to approve all completed samples for a generation at once
- Track sample statistics (approved/rejected/pending) in generation endpoints
- Create necessary request/response models for bulk operations
- Maintain consistency with existing approval patterns and error handling