### PR TITLE
Enable scheduler and auto-release seed data for easier dev setup

### DIFF
--- a/dev/seed-data.sql
+++ b/dev/seed-data.sql
@@ -285,3 +285,29 @@ WHERE
         'Isaac'
     )
 ON CONFLICT DO NOTHING;
+
+-- Set all items to RELEASED experimental state for easier development setup
+UPDATE specification.model 
+SET experimental_state_id = (SELECT id FROM research.experimental_state WHERE name = 'RELEASED')
+WHERE experimental_state_id IS NULL;
+
+UPDATE specification.prompt
+SET experimental_state_id = (SELECT id FROM research.experimental_state WHERE name = 'RELEASED')
+WHERE experimental_state_id IS NULL;
+
+UPDATE specification.template
+SET experimental_state_id = (SELECT id FROM research.experimental_state WHERE name = 'RELEASED')
+WHERE experimental_state_id IS NULL;
+
+-- Enable scheduler and set simple queue limits for development (users can tune later)
+INSERT INTO specification.scheduler_control (key, value) VALUES 
+    ('SCHEDULER_MODE', 'on'),
+    ('DEFAULT_MAX_QUEUED_TASKS', '10'),
+    ('MAX_TASKS_prompt', '10'),
+    ('MAX_TASKS_parse', '10'), 
+    ('MAX_TASKS_validate', '10'),
+    ('MAX_TASKS_server', '10'),
+    ('MAX_TASKS_render', '10'),
+    ('MAX_TASKS_post_process', '10'),
+    ('MAX_TASKS_prepare', '10')
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;

--- a/dev/seed-data.sql
+++ b/dev/seed-data.sql
@@ -301,7 +301,7 @@ WHERE experimental_state_id IS NULL;
 
 -- Enable scheduler and set simple queue limits for development (users can tune later)
 INSERT INTO specification.scheduler_control (key, value) VALUES 
-    ('SCHEDULER_MODE', 'on'),
+    ('SCHEDULER_MODE', '"on"'),
     ('DEFAULT_MAX_QUEUED_TASKS', '10'),
     ('MAX_TASKS_prompt', '10'),
     ('MAX_TASKS_parse', '10'), 


### PR DESCRIPTION
## High level overview

This PR adds two features to the `seed-data.sql` to make local development easier.

## Changes

The first is automatically setting the state of every model, prompt, and template in that file to `RELEASED` - otherwise, a user who wants to run mc-bench locally will have to do it via the UI which is time consuming, or construct the sql query themselves, which is an unnecessary hurdle.

The second is enabling the scheduler and setting basic queue limits in `seed-data.sql` - again another step that should be implemented out of the box to make things just "work", and also is annoying / time consuming to do via the frontend.

## Testing
Ran the seed file with and without these changes to confirm they actually fix the setup issues.
