### PR TITLE
Add OpenAI Responses API provider support

### DIFF
--- a/deps/admin-worker-requirements.in
+++ b/deps/admin-worker-requirements.in
@@ -3,7 +3,7 @@ psycopg2-binary>=2.9.10
 sqlalchemy>=2.0.36
 alembic>=1.14.0
 anthropic
-openai
+openai>=1.98.0
 mistralai
 reka-api
 jinja2

--- a/deps/admin-worker-requirements.txt
+++ b/deps/admin-worker-requirements.txt
@@ -159,7 +159,7 @@ mistralai==1.5.0
     # via -r admin-worker-requirements.in
 mypy-extensions==1.0.0
     # via typing-inspect
-openai==1.63.2
+openai==1.98.0
     # via -r admin-worker-requirements.in
 prometheus-client==0.21.1
     # via flower

--- a/src/mc_bench/apps/api/config.py
+++ b/src/mc_bench/apps/api/config.py
@@ -9,7 +9,9 @@ class Settings:
     GITHUB_EMAIL_SALT = os.environ["GITHUB_EMAIL_SALT"]
     EMAIL_SALT = os.environ["GITHUB_EMAIL_SALT"]
     ALGORITHM = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 7))
+    ACCESS_TOKEN_EXPIRE_MINUTES = int(
+        os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 7)
+    )
     REFRESH_TOKEN_EXPIRE_MINUTES = int(
         os.environ.get("REFRESH_TOKEN_EXPIRE_MINUTES", 60 * 24 * 7)
     )

--- a/src/mc_bench/apps/api/routers/comparison.py
+++ b/src/mc_bench/apps/api/routers/comparison.py
@@ -449,12 +449,19 @@ def get_leaderboard(
     query = (
         select(ModelLeaderboard)
         .join(Model, ModelLeaderboard.model_id == Model.id)
-        .join(ExperimentalState, Model.experimental_state_id == ExperimentalState.id, isouter=True)
+        .join(
+            ExperimentalState,
+            Model.experimental_state_id == ExperimentalState.id,
+            isouter=True,
+        )
         .where(
             ModelLeaderboard.metric_id == metric.id,
             ModelLeaderboard.test_set_id == test_set.id,
             ModelLeaderboard.vote_count >= minVotes,
-            (ExperimentalState.name.is_(None) | (ExperimentalState.name != 'DEPRECATED'))
+            (
+                ExperimentalState.name.is_(None)
+                | (ExperimentalState.name != "DEPRECATED")
+            ),
         )
         .order_by(ModelLeaderboard.elo_score.desc())
         .limit(limit)

--- a/src/mc_bench/clients/openai_responses.py
+++ b/src/mc_bench/clients/openai_responses.py
@@ -1,0 +1,34 @@
+import os
+
+import openai
+
+
+class OpenAIResponsesClient:
+    def __init__(self):
+        self.client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+    def send_prompt(self, **kwargs):
+        prompt_in_kwargs = "prompt" in kwargs
+        messages_in_kwargs = "messages" in kwargs
+        input_in_kwargs = "input" in kwargs
+
+        assert not (messages_in_kwargs and prompt_in_kwargs)
+        assert not (input_in_kwargs and (messages_in_kwargs or prompt_in_kwargs))
+        assert messages_in_kwargs or prompt_in_kwargs or input_in_kwargs
+        assert "model" in kwargs
+
+        # Convert prompt to input format for Responses API
+        if prompt_in_kwargs:
+            kwargs["input"] = kwargs.pop("prompt")
+        elif messages_in_kwargs:
+            # Convert messages format to input format
+            messages = kwargs.pop("messages")
+            if len(messages) == 1 and messages[0]["role"] == "user":
+                kwargs["input"] = messages[0]["content"]
+            else:
+                # For multi-turn conversations, use the messages format as input
+                kwargs["input"] = messages
+
+        # Use the OpenAI Responses API
+        response = self.client.responses.create(**kwargs)
+        return response.output_text

--- a/src/mc_bench/migrations/versions/8f8e8c00c1d0_add_openai_responses_provider.py
+++ b/src/mc_bench/migrations/versions/8f8e8c00c1d0_add_openai_responses_provider.py
@@ -1,0 +1,33 @@
+"""Add OpenAI Responses provider
+
+Revision ID: 8f8e8c00c1d0
+Revises: ffb71aaa0034
+Create Date: 2025-01-31 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8f8e8c00c1d0"
+down_revision: Union[str, None] = "473407e9d86e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""\
+        INSERT INTO specification.provider_class (created_by, name) VALUES (
+            (select id from auth.user where username = 'SYSTEM'),
+            'OPENAI_RESPONSES_SDK'
+        ) ON CONFLICT (name) DO NOTHING;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""\
+        DELETE FROM specification.provider_class 
+        WHERE name = 'OPENAI_RESPONSES_SDK';
+    """)

--- a/src/mc_bench/migrations/versions/8f8e8c00c1d0_add_openai_responses_provider.py
+++ b/src/mc_bench/migrations/versions/8f8e8c00c1d0_add_openai_responses_provider.py
@@ -27,6 +27,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # First delete any providers that reference this provider class
+    op.execute("""\
+        DELETE FROM specification.provider 
+        WHERE provider_class = 'OPENAI_RESPONSES_SDK';
+    """)
+    
+    # Then delete the provider class
     op.execute("""\
         DELETE FROM specification.provider_class 
         WHERE name = 'OPENAI_RESPONSES_SDK';

--- a/src/mc_bench/models/provider/__init__.py
+++ b/src/mc_bench/models/provider/__init__.py
@@ -6,6 +6,7 @@ from .gemini import GeminiProvider
 from .grok import GrokProvider
 from .mistral import MistralProvider
 from .openai import OpenAIProvider
+from .openai_responses import OpenAIResponsesProvider
 from .openrouter import OpenRouterProvider
 from .reka import RekaProvider
 from .zhipuai import ZhipuAIProvider
@@ -19,6 +20,7 @@ __all__ = [
     "GrokProvider",
     "MistralProvider",
     "OpenAIProvider",
+    "OpenAIResponsesProvider",
     "OpenRouterProvider",
     "RekaProvider",
     "ZhipuAIProvider",

--- a/src/mc_bench/models/provider/openai_responses.py
+++ b/src/mc_bench/models/provider/openai_responses.py
@@ -1,0 +1,10 @@
+from ._base import Provider
+
+
+class OpenAIResponsesProvider(Provider):
+    __mapper_args__ = {"polymorphic_identity": "OPENAI_RESPONSES_SDK"}
+
+    def get_client(self):
+        from mc_bench.clients.openai_responses import OpenAIResponsesClient
+
+        return OpenAIResponsesClient()

--- a/src/mc_bench/server/auth.py
+++ b/src/mc_bench/server/auth.py
@@ -230,7 +230,9 @@ class AuthManager:
         if expires_delta:
             expire = datetime.utcnow() + expires_delta
         else:
-            expire = datetime.utcnow() + timedelta(minutes=60 * 24 * 7)  # Default to 7 days
+            expire = datetime.utcnow() + timedelta(
+                minutes=60 * 24 * 7
+            )  # Default to 7 days
 
         # Add jti (JWT ID) claim for tracking revoked tokens
         token_id = str(uuid.uuid4())


### PR DESCRIPTION
## High level overview

This PR adds support for OpenAI Responses API.
It requires a newer version of OpenAI API, which I updated in the admin dependencies.
There's also some misc ruff formatting that wasn't caught in other PRs.
The actual code implementation in `openai_responses.py` probably could be cleaner but it's good enough.
The usage of polymorphic identities is still strange to me but I just followed along the existing code.

## Testing

I created a few runs locally and they ran.

## Notes

This doesn't really change much on our end, but I want to be able to future proof things, and build groundwork for more features. Consider how the responses api supports way more function / tool calling - what if the AIs could browse the web before building? That's not really supported here but in theory we could build off of having that infra somewhere.